### PR TITLE
fix: Prevent article hover effect from persisting outside article area

### DIFF
--- a/src/components/ArticlesHoverEffect.tsx
+++ b/src/components/ArticlesHoverEffect.tsx
@@ -90,17 +90,31 @@ export default function ArticlesHoverEffect() {
       }
     }
 
+    const handleSectionLeave = () => {
+      handleMouseLeave()
+    }
+
     const articleLinks = document.querySelectorAll('.article-link')
+    const articlesContainer = document.querySelector('.articles-container')
+
     articleLinks.forEach((link) => {
       link.addEventListener('mouseenter', handleArticleHover)
       link.addEventListener('mouseleave', handleArticleHover)
     })
+
+    // Add listener to the articles container to ensure hover effect resets when leaving the section
+    if (articlesContainer) {
+      articlesContainer.addEventListener('mouseleave', handleSectionLeave)
+    }
 
     return () => {
       articleLinks.forEach((link) => {
         link.removeEventListener('mouseenter', handleArticleHover)
         link.removeEventListener('mouseleave', handleArticleHover)
       })
+      if (articlesContainer) {
+        articlesContainer.removeEventListener('mouseleave', handleSectionLeave)
+      }
     }
   }, [handleMouseEnter, handleMouseLeave])
 

--- a/src/components/ArticlesSection.tsx
+++ b/src/components/ArticlesSection.tsx
@@ -37,7 +37,7 @@ export default async function ArticlesSection() {
         {/* Hover Image Container */}
         <ArticlesHoverEffect />
 
-        <div className="space-y-px bg-gray-800">
+        <div className="space-y-px bg-gray-800 articles-container">
           {articles.map((article) => {
             // Format date
             const date = new Date(article.publishedAt)


### PR DESCRIPTION
- Add mouseleave event listener to articles container to reset hover effect
- Ensures hover image disappears when mouse leaves the articles section
- Fixes issue where hover effect would continue tracking outside the article area

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 記事セクションを離れた際に、ホバーエフェクトが確実にリセットされるよう改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->