### PR TITLE
fix: Reset article hover effect on scroll

### DIFF
--- a/src/components/ArticlesHoverEffect.tsx
+++ b/src/components/ArticlesHoverEffect.tsx
@@ -94,6 +94,11 @@ export default function ArticlesHoverEffect() {
       handleMouseLeave()
     }
 
+    const handleScroll = () => {
+      // Reset hover effect on scroll
+      handleMouseLeave()
+    }
+
     const articleLinks = document.querySelectorAll('.article-link')
     const articlesContainer = document.querySelector('.articles-container')
 
@@ -107,6 +112,9 @@ export default function ArticlesHoverEffect() {
       articlesContainer.addEventListener('mouseleave', handleSectionLeave)
     }
 
+    // Add scroll listener to reset hover effect when scrolling
+    window.addEventListener('scroll', handleScroll, { passive: true })
+
     return () => {
       articleLinks.forEach((link) => {
         link.removeEventListener('mouseenter', handleArticleHover)
@@ -115,6 +123,7 @@ export default function ArticlesHoverEffect() {
       if (articlesContainer) {
         articlesContainer.removeEventListener('mouseleave', handleSectionLeave)
       }
+      window.removeEventListener('scroll', handleScroll)
     }
   }, [handleMouseEnter, handleMouseLeave])
 


### PR DESCRIPTION
Add scroll event listener to ArticlesHoverEffect to immediately reset the hover image preview when user scrolls. This prevents the hover effect from persisting after scrolling past the articles section.

Changes:
- Add handleScroll function to reset hover state
- Attach scroll listener with passive flag for performance
- Clean up scroll listener on component unmount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 記事のホバーエフェクトがスクロール時に適切にリセットされるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->