### PR TITLE
fix: Reduce sphere size on mobile devices to prevent viewport clipping

### DIFF
--- a/src/components/WebGLBackground.tsx
+++ b/src/components/WebGLBackground.tsx
@@ -15,6 +15,7 @@ const fragmentShader = `
   uniform vec2 iResolution;
   uniform float iTime;
   uniform float uScroll;
+  uniform float uSphereSize;
   varying vec2 vUv;
 
   #define MAX_STEPS 50
@@ -78,16 +79,7 @@ const fragmentShader = `
 
     q += vec3(sin(t*0.5), cos(t*0.3), sin(t*0.7)) * 0.3;
 
-    // Adjust sphere size based on aspect ratio for mobile devices
-    float aspect = iResolution.x / iResolution.y;
-    float sphereSize = 1.8;
-
-    // For portrait/mobile (aspect < 1.0), reduce sphere size significantly
-    if (aspect < 1.0) {
-      sphereSize = 1.8 * (0.5 + aspect * 0.3);
-    }
-
-    float sphere = sdSphere(q, sphereSize);
+    float sphere = sdSphere(q, uSphereSize);
 
     float scrollNoise = abs(velocity) * 4.0;
     float displacement = fbm(q * (1.2 + scrollNoise*0.2) + vec3(0.0, t * (0.8 + scrollNoise), 0.0));
@@ -210,6 +202,10 @@ export default function WebGLBackground() {
     renderer.setPixelRatio(1) // Fixed at 1 for better performance
     containerRef.current.appendChild(renderer.domElement)
 
+    // Calculate initial sphere size based on aspect ratio
+    const initialAspect = window.innerWidth / window.innerHeight
+    const initialSphereSize = initialAspect < 1.0 ? 1.8 * (0.5 + initialAspect * 0.3) : 1.8
+
     const geometry = new THREE.PlaneGeometry(2, 2)
     const material = new THREE.ShaderMaterial({
       vertexShader,
@@ -218,6 +214,7 @@ export default function WebGLBackground() {
         iTime: { value: 0 },
         iResolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
         uScroll: { value: 0 },
+        uSphereSize: { value: initialSphereSize },
       },
       depthWrite: false,
       depthTest: false,
@@ -232,6 +229,10 @@ export default function WebGLBackground() {
       const height = window.innerHeight
       renderer.setSize(width, height)
       material.uniforms.iResolution.value.set(width, height)
+
+      // Calculate sphere size based on aspect ratio
+      const aspect = width / height
+      material.uniforms.uSphereSize.value = aspect < 1.0 ? 1.8 * (0.5 + aspect * 0.3) : 1.8
     }
 
     window.addEventListener('resize', handleResize)


### PR DESCRIPTION
Adjusts sphere size dynamically based on aspect ratio. For portrait/mobile viewports (aspect < 1.0), the sphere is scaled down significantly to ensure it remains fully visible without clipping at screen edges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * WebGL背景の球の表示サイズを画面のアスペクト比に合わせて自動調整。初期サイズの算出とリサイズ時の動的更新により、モバイルや縦表示での表示崩れや不整合を改善し、より一貫した見た目を提供。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->