### PR TITLE
chore: harden Bun installs

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   NODE_VERSION: "22"
   BUN_VERSION: "latest"
+  BUN_INSTALL_FLAGS: "--frozen-lockfile --ignore-scripts"
 
 jobs:
   build-and-deploy:
@@ -32,8 +33,13 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Verify Bun security feature support
+        run: |
+          bun --version
+          bun -e "const [major, minor] = Bun.version.split('.').map(Number); if (major < 1 || (major === 1 && minor < 3)) { console.error('Bun 1.3+ is required for minimumReleaseAge enforcement'); process.exit(1); }"
+
       - name: Install dependencies
-        run: bun install
+        run: bun install ${{ env.BUN_INSTALL_FLAGS }}
 
       - name: Prepare build env
         run: |

--- a/.github/workflows/jules-dependency-update.yml
+++ b/.github/workflows/jules-dependency-update.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       prompt:
         description: 'タスク指示'
-        default: 'Update all dependencies with bun update --latest. Verify with bun run lint && bun run build.'
+        default: 'Update all dependencies with bun update --latest, respecting bunfig.toml supply-chain hardening. Verify with bun install --frozen-lockfile --ignore-scripts && bun run lint && bun run build.'
         type: string
 
 env:
@@ -28,7 +28,7 @@ jobs:
             -H "X-Goog-Api-Key: ${{ secrets.JULES_API_KEY }}" \
             -d @- <<EOF
           {
-            "prompt": "${{ inputs.prompt || 'Update all dependencies with bun update --latest. Verify with bun run lint && bun run build.' }}",
+            "prompt": "${{ inputs.prompt || 'Update all dependencies with bun update --latest, respecting bunfig.toml supply-chain hardening. Verify with bun install --frozen-lockfile --ignore-scripts && bun run lint && bun run build.' }}",
             "sourceContext": {
               "source": "sources/github/${{ github.repository }}",
               "githubRepoContext": { "startingBranch": "${{ github.ref_name }}" }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Keep transitive dependencies on registry-resolved packages only.
+block-exotic-subdeps=true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,9 @@
+[install]
+# Supply-chain hardening: avoid resolving package versions published in the last 3 days.
+minimumReleaseAge = 259200
+# Keep compiler/runtime type packages unblocked so routine toolchain updates do not stall.
+minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
+# Do not run project or dependency lifecycle scripts during dependency installation.
+ignoreScripts = true
+# Block transitive dependencies that resolve from non-registry sources when supported by Bun.
+blockExoticSubdeps = true

--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
     "src/**/*.{json,css,scss}": [
       "biome format --write"
     ]
-  }
+  },
+  "trustedDependencies": []
 }


### PR DESCRIPTION
### Motivation
- 依存関係のサプライチェーンを強化して、公開直後のパッケージや非レジストリ由来のトランジティブ依存からのリスクを低減するため。 
- CI / 自動更新フローでも lifecycle スクリプト実行や非安全なサブデプスを無効化してデプロイ時の攻撃面を縮小するため。 
- 今後のパッケージビルド実行は明示的に `trustedDependencies` による承認で管理する方針にするため。 

### Description
- 追加で `bunfig.toml` を導入し `minimumReleaseAge = 259200`、`minimumReleaseAgeExcludes = ["@types/bun","typescript"]`、`ignoreScripts = true`、`blockExoticSubdeps = true` を設定した。 
- 互換のための `.npmrc` を追加し `block-exotic-subdeps=true` を設定した。 
- `package.json` に空の `trustedDependencies` 配列を追加してライフサイクルスクリプトの許可を今後明示管理するようにした。 
- GitHub Actions の `deploy-gh-pages` ワークフローを更新して `BUN_INSTALL_FLAGS = "--frozen-lockfile --ignore-scripts"` を使い `bun` バージョンが `1.3+` であることを検証してから `bun install ${{ env.BUN_INSTALL_FLAGS }}` を実行するようにした。 
- `jules-dependency-update` ワークフローのデフォルトプロンプトを、`bunfig.toml` のハードニングを尊重するように修正した。 

### Testing
- `bun run format` を実行してワークフロー / 設定ファイルのフォーマットを確認済み（成功）。 
- `bun run lint` を実行して `biome` / `tsc` / `markuplint` のチェックは成功した。 
- `bun run build` を実行してプロジェクトのビルド（SSG / prerender 含む）は成功した。 
- `bun install --frozen-lockfile --ignore-scripts` はこの環境でレジストリの `403` により完走できなかったが、ワークフロー上では `--frozen-lockfile --ignore-scripts` を使うように設定している（実行可否は実行環境のネットワーク/レジストリアクセスに依存）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0401bf48a8832f8ea223b141c015ec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **保守・その他**
  * サプライチェーンセキュリティの強化とインストール制御を実装しました。依存関係の検証機能が強化され、パッケージの最小リリース期間ポリシーと外部ソース依存の制限が追加されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YunosukeYoshino/Portfolio/pull/76)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->