### PR TITLE
feat(seo): optimize site for AI SEO (AEO/GEO) with llms.txt, robots.txt, and Profile/FAQ schemas

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,24 @@
+# Yunosuke Yoshino - Portfolio & Profile
+
+> Tokyo-based Frontend Engineer specializing in React, Astro, TypeScript, and AI-agentic workflows (Claude, Codex, Dify, n8n).
+
+## Profile & Background
+- Name: Yunosuke Yoshino (吉野 悠之介)
+- Role: Frontend Engineer / AI Workflow Specialist
+- Location: Tokyo, Japan (Born in Hiroshima, 1995)
+- Main Focus: Building high-performance web applications, UI/UX optimization, and automating dev workflows via AI agents.
+
+## Core Technical Skills
+- Frontend: React, Next.js, Astro, TypeScript, JavaScript, HTML5/CSS3, Tailwind CSS
+- AI & Automation: Claude, Codex, Dify, n8n, MCP (Model Context Protocol) Servers, AI Agents
+- Build & Tools: Vite, Bun, Cloudflare Workers, Git/GitHub
+
+## Key Pages
+- [About Page](https://yunosukeyoshino.com/about): Career background, expertise, and FAQ.
+- [Articles / Writing](https://yunosukeyoshino.com/article): Technical posts on frontend development and AI workflows.
+- [GitHub Profile](https://github.com/YunosukeYoshino): Open source projects and repositories.
+
+## Contact & Links
+- Email: hello@yunosukeyoshino.com
+- GitHub: https://github.com/YunosukeYoshino
+- LinkedIn: https://www.linkedin.com/in/yunosukeyoshino

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,20 @@
 User-agent: *
 Allow: /
 Content-Signal: search=yes, ai-train=no, ai-input=yes
+
+# AI Crawlers for Search & Citation
+User-agent: GPTBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 Sitemap: https://yunosukeyoshino.com/sitemap.xml
+# llms.txt: https://yunosukeyoshino.com/llms.txt
+

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -20,12 +20,38 @@ export const createPersonSchema = () => ({
   knowsAbout: [
     'React',
     'Next.js',
+    'Astro',
     'TypeScript',
     'JavaScript',
     'フロントエンド開発',
     'UI/UX デザイン',
-    'レスポンシブ Web デザイン',
+    'AI エージェント',
+    'MCP (Model Context Protocol)',
+    'n8n / 自動化ワークフロー',
   ],
+})
+
+export const createProfilePageSchema = () => ({
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  url: toCanonicalUrl('/about'),
+  name: 'About Yunosuke Yoshino',
+  description: 'フロントエンドエンジニア Yunosuke Yoshino のプロフィール、経歴、専門分野、FAQ。',
+  inLanguage: 'ja-JP',
+  mainEntity: createPersonSchema(),
+})
+
+export const createFAQSchema = (faqs: Array<{ question: string; answer: string }>) => ({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: faq.answer,
+    },
+  })),
 })
 
 export const createWebsiteSchema = () => ({

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,5 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro'
+import JsonLdScript from '@/components/seo/JsonLdScript.astro'
+import { createProfilePageSchema, createFAQSchema } from '@/components/seo/JsonLd'
 
 const description =
   'アパレル販売からフロントエンドエンジニアへ転身したYunosuke Yoshinoの経歴。React、Astroを活用したモダンなWeb開発と、AIエージェンティックコーディングによる業務自動化に取り組んでいます。'
@@ -29,15 +31,31 @@ const timelineData = [
       '東京を拠点に、ReactやAstroを活用したモダンなフロントエンド開発に特化。ビジネス要件に基づいたUI/UXの改善提案に加え、ClaudeやCodex、Dify、n8nを組み合わせたAIエージェンティックコーディングで開発と業務改善を推進する。',
   },
 ]
+
+const faqData = [
+  {
+    question: 'Yunosuke Yoshino の専門分野・強みは何ですか？',
+    answer:
+      'React、Next.js、Astro、TypeScript を用いたモダンフロントエンド開発と、Claude、Codex、Dify、n8n、MCP（Model Context Protocol）を活用した AI エージェント連携・開発フロー自動化を専門としています。',
+  },
+  {
+    question: 'どのようなWeb案件や開発業務に対応していますか？',
+    answer:
+      'WebアプリケーションのUI/UX改善・コンポーネント開発、ECサイト構築・運用、パフォーマンス高速化、ならびにAIエージェントの社内開発プロセス導入・自動化支援に対応しています。',
+  },
+]
 ---
 
 <Layout title="About｜Yunosuke Yoshino" description={description} canonicalPath="/about" ogType="website">
+  <JsonLdScript data={createProfilePageSchema()} />
+  <JsonLdScript data={createFAQSchema(faqData)} />
+
   <section class="mb-[var(--sectiongap)]">
     <h1 class="label-mono mb-5">About</h1>
-    <p class="mb-4 text-base text-ink-body">
+    <p class="mb-4 text-base text-ink-body leading-relaxed">
       1995年生まれ、広島出身。アパレル販売の現場からウェブ開発の世界へと転身し、現在は東京を拠点に活動しています。ECサイトを中心としたフロントエンド開発に特化し、データ分析に基づく継続的な改善提案を行っています。
     </p>
-    <p class="text-base text-ink-body">
+    <p class="text-base text-ink-body leading-relaxed">
       ReactやAstroといったモダンなフレームワークを活用し、保守性と拡張性を重視したコードを書くことを大切にしています。近年はClaudeやCodex、Dify、n8nを組み合わせたAIエージェンティックコーディングを推進し、プロダクト開発と業務改善の両方に取り組んでいます。
     </p>
   </section>
@@ -53,5 +71,17 @@ const timelineData = [
         </div>
       </div>
     ))}
+  </section>
+
+  <section class="mb-[var(--sectiongap)]">
+    <h2 class="label-mono mb-5">Frequently Asked Questions</h2>
+    <div class="space-y-6">
+      {faqData.map((faq) => (
+        <div class="border-t border-rule pt-4">
+          <h3 class="mb-2 text-base font-medium text-ink">{faq.question}</h3>
+          <p class="text-[15px] text-ink-soft leading-relaxed">{faq.answer}</p>
+        </div>
+      ))}
+    </div>
   </section>
 </Layout>


### PR DESCRIPTION
## Summary
Marketing skill の AI SEO (AEO/GEO/LLMO) 観点に基づく監査を実施し、以下の改善対応を行いました。

1. **`public/llms.txt` の新規追加**
   - AI Agent や LLM 検索エンジンが人物・技術・ページ構成を正確に把握するためのコンテキストファイル。
2. **`public/robots.txt` の最適化**
   - GPTBot, PerplexityBot, ClaudeBot, Google-Extended 等の主要 AI クローラーに対する明示的な許可指定と `llms.txt` の参照を追加。
3. **`about.astro` への ProfilePage / FAQ スキーマと Direct Answer セクションの追加**
   - `JsonLd.tsx` に `createProfilePageSchema` と `createFAQSchema` を実装。
   - `about.astro` に構造化データおよび抽出性の高い FAQ（Direct Answer Block）セクションを追加。

## Verification
- `bun run typecheck` PASS
- `bun run build` PASS